### PR TITLE
Use the same flow for Percy and other screenshot renderers

### DIFF
--- a/src/lib/react/ReactComponentServer.spec.tsx
+++ b/src/lib/react/ReactComponentServer.spec.tsx
@@ -13,6 +13,7 @@ describe("ReactComponentServer", () => {
     let rendered = false;
     await server.serve(
       {
+        name: "test",
         reactNode: <div>Hello, World!</div>,
         remoteStylesheetUrls: ["https://fonts.googleapis.com/css?family=Roboto"]
       },

--- a/src/lib/react/ReactComponentServer.ts
+++ b/src/lib/react/ReactComponentServer.ts
@@ -162,6 +162,7 @@ export class ReactComponentServer {
 }
 
 export interface NodeDescription {
+  name: string;
   reactNode: React.ReactNode;
   remoteStylesheetUrls: string[];
 }

--- a/src/lib/react/ReactScreenshotTaker.spec.tsx
+++ b/src/lib/react/ReactScreenshotTaker.spec.tsx
@@ -56,6 +56,7 @@ describe("ReactScreenshotTaker", () => {
         mockScreenshotRenderer
       );
       const node: NodeDescription = {
+        name: "test",
         reactNode: <div>Hello, World!</div>,
         remoteStylesheetUrls: []
       };
@@ -75,6 +76,7 @@ describe("ReactScreenshotTaker", () => {
         mockScreenshotRenderer
       );
       const node: NodeDescription = {
+        name: "test",
         reactNode: <div>Hello, World!</div>,
         remoteStylesheetUrls: []
       };

--- a/src/lib/react/ReactScreenshotTaker.spec.tsx
+++ b/src/lib/react/ReactScreenshotTaker.spec.tsx
@@ -66,6 +66,7 @@ describe("ReactScreenshotTaker", () => {
         expect.anything()
       );
       expect(mockScreenshotRenderer.render).toHaveBeenCalledWith(
+        "test",
         expect.stringMatching(":1234/rendered")
       );
     });
@@ -89,6 +90,7 @@ describe("ReactScreenshotTaker", () => {
         expect.anything()
       );
       expect(mockScreenshotRenderer.render).toHaveBeenCalledWith(
+        "test",
         expect.stringMatching(":1234/rendered"),
         {
           width: 1024,

--- a/src/lib/react/ReactScreenshotTaker.ts
+++ b/src/lib/react/ReactScreenshotTaker.ts
@@ -1,9 +1,5 @@
 import { ScreenshotRenderer, Viewport } from "../screenshot-renderer/api";
-import { HttpScreenshotRenderer } from "../screenshot-renderer/HttpScreenshotRenderer";
-import {
-  SCREENSHOT_MODE,
-  SCREENSHOT_SERVER_PORT
-} from "../screenshot-server/config";
+import { SCREENSHOT_MODE } from "../screenshot-server/config";
 import { NodeDescription, ReactComponentServer } from "./ReactComponentServer";
 
 /**
@@ -11,10 +7,8 @@ import { NodeDescription, ReactComponentServer } from "./ReactComponentServer";
  */
 export class ReactScreenshotTaker {
   constructor(
-    private readonly componentServer = new ReactComponentServer(),
-    private readonly screenshotRenderer: ScreenshotRenderer = new HttpScreenshotRenderer(
-      `http://localhost:${SCREENSHOT_SERVER_PORT}`
-    )
+    private readonly componentServer: ReactComponentServer,
+    private readonly screenshotRenderer: ScreenshotRenderer
   ) {}
 
   async start() {
@@ -34,12 +28,12 @@ export class ReactScreenshotTaker {
   async render(node: NodeDescription, viewport?: Viewport) {
     return this.componentServer.serve(node, async (port, path) => {
       const url =
-        SCREENSHOT_MODE === "local"
-          ? `http://localhost:${port}${path}`
-          : `http://host.docker.internal:${port}${path}`;
+        SCREENSHOT_MODE === "docker"
+          ? `http://host.docker.internal:${port}${path}`
+          : `http://localhost:${port}${path}`;
       return viewport
-        ? this.screenshotRenderer.render(url, viewport)
-        : this.screenshotRenderer.render(url);
+        ? this.screenshotRenderer.render(node.name, url, viewport)
+        : this.screenshotRenderer.render(node.name, url);
     });
   }
 }

--- a/src/lib/react/ReactScreenshotTest.ts
+++ b/src/lib/react/ReactScreenshotTest.ts
@@ -110,7 +110,7 @@ export class ReactScreenshotTest {
     describe(this.componentName, () => {
       expect.extend({ toMatchImageSnapshot });
       const screenshotRenderer =
-        SCREENSHOT_MODE == "percy"
+        SCREENSHOT_MODE === "percy"
           ? new PercyScreenshotRenderer()
           : new HttpScreenshotRenderer(
               `http://localhost:${SCREENSHOT_SERVER_PORT}`

--- a/src/lib/screenshot-renderer/ChromeScreenshotRenderer.spec.ts
+++ b/src/lib/screenshot-renderer/ChromeScreenshotRenderer.spec.ts
@@ -79,9 +79,9 @@ describe("ChromeScreenshotRenderer", () => {
   describe("render", () => {
     it("cannot render without first starting it", async () => {
       const renderer = new ChromeScreenshotRenderer();
-      await expect(renderer.render("http://example.com")).rejects.toEqual(
-        new Error("Please call start() once before render().")
-      );
+      await expect(
+        renderer.render("test", "http://example.com")
+      ).rejects.toEqual(new Error("Please call start() once before render()."));
     });
 
     it("takes a screenshot", async () => {
@@ -89,7 +89,7 @@ describe("ChromeScreenshotRenderer", () => {
       mockPage.screenshot.mockResolvedValue(dummyBinaryScreenshot);
       const renderer = new ChromeScreenshotRenderer();
       await renderer.start();
-      const screenshot = await renderer.render("http://example.com");
+      const screenshot = await renderer.render("test", "http://example.com");
       expect(screenshot).toBe(dummyBinaryScreenshot);
       expect(mockPage.goto).toHaveBeenCalledWith("http://example.com");
       expect(mockPage.screenshot).toHaveBeenCalledWith({
@@ -101,7 +101,7 @@ describe("ChromeScreenshotRenderer", () => {
     it("sets the viewport if provided", async () => {
       const renderer = new ChromeScreenshotRenderer();
       await renderer.start();
-      await renderer.render("http://example.com", {
+      await renderer.render("test", "http://example.com", {
         width: 1024,
         height: 768
       });
@@ -114,7 +114,7 @@ describe("ChromeScreenshotRenderer", () => {
     it("does not set the viewport if not provided", async () => {
       const renderer = new ChromeScreenshotRenderer();
       await renderer.start();
-      await renderer.render("http://example.com");
+      await renderer.render("test", "http://example.com");
       expect(mockPage.setViewport).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/screenshot-renderer/ChromeScreenshotRenderer.ts
+++ b/src/lib/screenshot-renderer/ChromeScreenshotRenderer.ts
@@ -21,7 +21,7 @@ export class ChromeScreenshotRenderer implements ScreenshotRenderer {
     await this.browser.close();
   }
 
-  async render(url: string, viewport?: Viewport) {
+  async render(_name: string, url: string, viewport?: Viewport) {
     if (!this.browser) {
       throw new Error("Please call start() once before render().");
     }

--- a/src/lib/screenshot-renderer/HttpScreenshotRenderer.spec.ts
+++ b/src/lib/screenshot-renderer/HttpScreenshotRenderer.spec.ts
@@ -24,7 +24,7 @@ describe("HttpScreenshotRenderer", () => {
     it("takes a screenshot", async () => {
       const renderer = new HttpScreenshotRenderer(SERVER_URL);
       await renderer.start();
-      const screenshot = await renderer.render("http://example.com");
+      const screenshot = await renderer.render("test", "http://example.com");
       expect(screenshot).toBe(dummyBinaryScreenshot);
       expect(axios.post).toHaveBeenCalledWith(
         "http://localhost:1234/render",
@@ -40,7 +40,7 @@ describe("HttpScreenshotRenderer", () => {
     it("sets the viewport if provided", async () => {
       const renderer = new HttpScreenshotRenderer(SERVER_URL);
       await renderer.start();
-      await renderer.render("http://example.com", {
+      await renderer.render("test", "http://example.com", {
         width: 1024,
         height: 768
       });
@@ -60,7 +60,7 @@ describe("HttpScreenshotRenderer", () => {
     it("does not set the viewport if not provided", async () => {
       const renderer = new HttpScreenshotRenderer(SERVER_URL);
       await renderer.start();
-      await renderer.render("http://example.com");
+      await renderer.render("test", "http://example.com");
       expect(axios.post).toHaveBeenCalledWith(
         expect.anything(),
         {

--- a/src/lib/screenshot-renderer/HttpScreenshotRenderer.ts
+++ b/src/lib/screenshot-renderer/HttpScreenshotRenderer.ts
@@ -18,7 +18,7 @@ export class HttpScreenshotRenderer implements ScreenshotRenderer {
     // Do nothing.
   }
 
-  async render(url: string, viewport?: Viewport) {
+  async render(_name: string, url: string, viewport?: Viewport) {
     try {
       const response = await axios.post(
         `${this.baseUrl}/render`,

--- a/src/lib/screenshot-renderer/PercyScreenshotRenderer.ts
+++ b/src/lib/screenshot-renderer/PercyScreenshotRenderer.ts
@@ -1,0 +1,52 @@
+import { Viewport } from "puppeteer";
+import { Browser, launchChrome } from "../browser/chrome";
+import { ScreenshotRenderer } from "./api";
+
+/**
+ * A screenshot renderer that uses Percy to take and compare screenshots.
+ */
+export class PercyScreenshotRenderer implements ScreenshotRenderer {
+  private browser: Browser | null = null;
+
+  constructor() {}
+
+  async start() {
+    this.browser = await launchChrome();
+  }
+
+  async stop() {
+    if (this.browser) {
+      await this.browser.close();
+    }
+  }
+
+  async render(name: string, url: string, viewport?: Viewport) {
+    if (!this.browser) {
+      throw new Error("Browser was not launched successfully.");
+    }
+    const page = await this.browser.newPage();
+    await page.goto(url);
+    let percy: typeof import("@percy/puppeteer");
+    try {
+      percy = await import("@percy/puppeteer");
+    } catch (e) {
+      throw new Error(
+        `Please install the '@percy/puppeteer' package:
+    
+    Using NPM:
+    $ npm install -D @percy/puppeteer
+    
+    Using Yarn:
+    $ yarn add -D @percy/puppeteer`
+      );
+    }
+    await percy.percySnapshot(
+      page,
+      name,
+      viewport && {
+        widths: [viewport.width / (viewport.deviceScaleFactor || 1)]
+      }
+    );
+    return null;
+  }
+}

--- a/src/lib/screenshot-renderer/api.ts
+++ b/src/lib/screenshot-renderer/api.ts
@@ -8,7 +8,16 @@
 export interface ScreenshotRenderer {
   start(): Promise<void>;
   stop(): Promise<void>;
-  render(url: string, viewport?: Viewport): Promise<Buffer>;
+
+  /**
+   * Returns a buffer representing a PNG screenshot, or `null` when screenshot
+   * comparison is delegated to a third-party.
+   */
+  render(
+    name: string,
+    url: string,
+    viewport?: Viewport
+  ): Promise<Buffer | null>;
 }
 
 export interface Viewport {

--- a/src/lib/screenshot-server/LocalScreenshotServer.spec.ts
+++ b/src/lib/screenshot-server/LocalScreenshotServer.spec.ts
@@ -30,10 +30,14 @@ describe("LocalScreenshotServer", () => {
         height: 768
       }
     });
-    expect(mockRenderer.render).toHaveBeenCalledWith("http://example.com", {
-      with: 1024,
-      height: 768
-    });
+    expect(mockRenderer.render).toHaveBeenCalledWith(
+      "screenshot",
+      "http://example.com",
+      {
+        with: 1024,
+        height: 768
+      }
+    );
 
     await server.stop();
     expect(mockRenderer.stop).toHaveBeenCalled();
@@ -49,7 +53,10 @@ describe("LocalScreenshotServer", () => {
     await axios.post(`http://localhost:${port}/render`, {
       url: "http://example.com"
     });
-    expect(mockRenderer.render).toHaveBeenCalledWith("http://example.com");
+    expect(mockRenderer.render).toHaveBeenCalledWith(
+      "screenshot",
+      "http://example.com"
+    );
 
     await server.stop();
     expect(mockRenderer.stop).toHaveBeenCalled();

--- a/src/lib/screenshot-server/LocalScreenshotServer.ts
+++ b/src/lib/screenshot-server/LocalScreenshotServer.ts
@@ -30,8 +30,8 @@ export class LocalScreenshotServer implements ScreenshotServer {
       const { url } = req.body;
       const { viewport } = req.body;
       const screenshot = await (viewport
-        ? this.renderer.render(url, viewport)
-        : this.renderer.render(url));
+        ? this.renderer.render("screenshot", url, viewport)
+        : this.renderer.render("screenshot", url));
       res.contentType("image/png");
       res.end(screenshot);
     });


### PR DESCRIPTION
This introduces PercyScreenshotRenderer, which is used in the same way as other renderers, eliminating a confusing fork in the screenshot logic.