### PR TITLE
Add SCREENSHOT_SERVER_URL environment variable

### DIFF
--- a/src/lib/react/ReactScreenshotTest.ts
+++ b/src/lib/react/ReactScreenshotTest.ts
@@ -4,7 +4,7 @@ import { toMatchImageSnapshot } from "jest-image-snapshot";
 import { Viewport } from "../screenshot-renderer/api";
 import {
   SCREENSHOT_MODE,
-  SCREENSHOT_SERVER_PORT
+  SCREENSHOT_SERVER_URL
 } from "../screenshot-server/config";
 import { ReactComponentServer } from "./ReactComponentServer";
 
@@ -153,7 +153,7 @@ export class ReactScreenshotTest {
   private async render(name: string, url: string, viewport: Viewport) {
     try {
       const response = await axios.post(
-        `http://localhost:${SCREENSHOT_SERVER_PORT}/render`,
+        `${SCREENSHOT_SERVER_URL}/render`,
         {
           name,
           url,

--- a/src/lib/screenshot-server/config.ts
+++ b/src/lib/screenshot-server/config.ts
@@ -5,6 +5,10 @@ export const SCREENSHOT_SERVER_PORT = parseInt(
   10
 );
 
+export const SCREENSHOT_SERVER_URL =
+  process.env.SCREENSHOT_SERVER_URL ||
+  `http://localhost:${SCREENSHOT_SERVER_PORT}`;
+
 export const SCREENSHOT_MODE = getScreenshotMode();
 
 function getScreenshotMode(): "local" | "docker" | "percy" {


### PR DESCRIPTION
This can be useful if someone decides to run their screenshot server elsewhere, for example.