### PR TITLE
Fixing encoding issue when css injected in style tag

### DIFF
--- a/src/lib/react/ReactComponentServer.ts
+++ b/src/lib/react/ReactComponentServer.ts
@@ -122,7 +122,9 @@ export class ReactComponentServer {
               href: url,
             })
           ),
-          React.createElement("style", null, readRecordedCss())
+          React.createElement("style", {
+            dangerouslySetInnerHTML: { __html: readRecordedCss() },
+          })
         ),
         React.createElement("body", null, node.reactNode)
       )


### PR DESCRIPTION
## What does this PR fix?
### Issue:
Quotes in css are encoded, for example, a CSS file having content like:
```
html, body {
    font-family: "Open Sans", sans-serif;
}
```

The above CSS when injected in the DOM like:
```
html, body {
    font-family: &quot;Open Sans&quot;, sans-serif;
}
```

Tis basically breaks the style, this PR fixes that.