### PR TITLE
Support javascript url

### DIFF
--- a/src/lib/react/ReactComponentServer.spec.tsx
+++ b/src/lib/react/ReactComponentServer.spec.tsx
@@ -18,6 +18,7 @@ describe("ReactComponentServer", () => {
         remoteStylesheetUrls: [
           "https://fonts.googleapis.com/css?family=Roboto",
         ],
+        remoteJavascriptUrls: [],
       },
       async (port, path) => {
         const { body } = await fetch(`http://localhost:${port}${path}`);

--- a/src/lib/react/ReactComponentServer.ts
+++ b/src/lib/react/ReactComponentServer.ts
@@ -122,6 +122,12 @@ export class ReactComponentServer {
               href: url,
             })
           ),
+          ...node.remoteJavascriptUrls.map((src) =>
+              React.createElement("script", {
+                src,
+                type: "application/javascript",
+              })
+          ),
           React.createElement("style", {
             dangerouslySetInnerHTML: { __html: readRecordedCss() },
           })
@@ -196,4 +202,5 @@ export interface NodeDescription {
   name: string;
   reactNode: React.ReactNode;
   remoteStylesheetUrls: string[];
+  remoteJavascriptUrls: string[];
 }

--- a/src/lib/react/ReactComponentServer.ts
+++ b/src/lib/react/ReactComponentServer.ts
@@ -88,6 +88,12 @@ export class ReactComponentServer {
                 href: url,
               })
             ),
+            ...node.remoteJavascriptUrls.map((src) =>
+                React.createElement("script", {
+                  src,
+                  type: "application/javascript",
+                })
+            ),
             React.createElement("style", {
               dangerouslySetInnerHTML: { __html: readRecordedCss() },
             }),

--- a/src/lib/react/ReactScreenshotTest.ts
+++ b/src/lib/react/ReactScreenshotTest.ts
@@ -37,6 +37,8 @@ export class ReactScreenshotTest {
 
   private readonly _remoteStylesheetUrls: string[] = [];
 
+  private readonly _remoteJavascriptUrls: string[] = [];
+
   private ran = false;
 
   /**
@@ -94,6 +96,11 @@ export class ReactScreenshotTest {
 
   remoteStylesheet(stylesheetUrl: string) {
     this._remoteStylesheetUrls.push(stylesheetUrl);
+    return this;
+  }
+
+  remoteJavascript(javascriptUrls: string) {
+    this._remoteJavascriptUrls.push(javascriptUrls);
     return this;
   }
 
@@ -155,6 +162,7 @@ export class ReactScreenshotTest {
                   name,
                   reactNode: shot,
                   remoteStylesheetUrls: this._remoteStylesheetUrls,
+                  remoteJavascriptUrls: this._remoteJavascriptUrls,
                 },
                 async (port, path) => {
                   const url =


### PR DESCRIPTION
For some react components javascript files are required. As project got remoteStylesheetUrls, i think remoteJavascriptUrls would be helful too 