### PR TITLE
Use host network for docker on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ which platform you run your tests on.
 You can override this behaviour by setting the `SCREENSHOT_MODE` environment
 variable to `local`, which will always use a local browser instead of Docker.
 
+_Note: On Linux, `react-screenshot-test` will run Docker using host network mode on port 3001_
+
 ## CSS support
 
 CSS-in-JS libraries such as Emotion and Styled Components are supported.

--- a/src/lib/docker-entrypoint.ts
+++ b/src/lib/docker-entrypoint.ts
@@ -3,7 +3,7 @@ import { LocalScreenshotServer } from "./screenshot-server/LocalScreenshotServer
 
 const screenshotServer = new LocalScreenshotServer(
   new PuppeteerScreenshotRenderer(),
-  3000
+  3001
 );
 screenshotServer
   .start()

--- a/src/lib/react/ReactScreenshotTest.ts
+++ b/src/lib/react/ReactScreenshotTest.ts
@@ -176,8 +176,9 @@ export class ReactScreenshotTest {
                   remoteStylesheetUrls: this._remoteStylesheetUrls,
                 },
                 async (port, path) => {
+                  // docker.interval is only available on window and mac
                   const url =
-                    SCREENSHOT_MODE === "docker"
+                    SCREENSHOT_MODE === "docker" && process.platform !== "linux"
                       ? `http://host.docker.internal:${port}${path}`
                       : `http://localhost:${port}${path}`;
                   return this.render(name, url, viewport);

--- a/src/lib/screenshot-server/DockerizedScreenshotServer.ts
+++ b/src/lib/screenshot-server/DockerizedScreenshotServer.ts
@@ -100,6 +100,17 @@ async function removeLeftoverContainers(docker: Docker) {
 }
 
 async function startContainer(docker: Docker, port: number) {
+  let hostConfig: Docker.ContainerCreateOptions["HostConfig"] = {
+    PortBindings: {
+      "3000/tcp": [{ HostPort: `${port}` }],
+    },
+  };
+  if (process.platform === "linux") {
+    hostConfig = {
+      NetworkMode: "host",
+    };
+  }
+
   const container = await docker.createContainer({
     Image: DOCKER_IMAGE_TAG,
     AttachStdin: false,
@@ -112,11 +123,7 @@ async function startContainer(docker: Docker, port: number) {
       "3000/tcp": {},
     },
     Env: [`SCREENSHOT_LOGGING_LEVEL=${getLoggingLevel()}`],
-    HostConfig: {
-      PortBindings: {
-        "3000/tcp": [{ HostPort: `${port}` }],
-      },
-    },
+    HostConfig: hostConfig,
   });
   await container.start();
   const stream = await container.logs({

--- a/src/lib/screenshot-server/DockerizedScreenshotServer.ts
+++ b/src/lib/screenshot-server/DockerizedScreenshotServer.ts
@@ -102,7 +102,7 @@ async function removeLeftoverContainers(docker: Docker) {
 async function startContainer(docker: Docker, port: number) {
   let hostConfig: Docker.ContainerCreateOptions["HostConfig"] = {
     PortBindings: {
-      "3000/tcp": [{ HostPort: `${port}` }],
+      "3001/tcp": [{ HostPort: `${port}` }],
     },
   };
   if (process.platform === "linux") {
@@ -120,7 +120,7 @@ async function startContainer(docker: Docker, port: number) {
     OpenStdin: false,
     StdinOnce: false,
     ExposedPorts: {
-      "3000/tcp": {},
+      "3001/tcp": {},
     },
     Env: [`SCREENSHOT_LOGGING_LEVEL=${getLoggingLevel()}`],
     HostConfig: hostConfig,

--- a/src/lib/screenshot-server/DockerizedScreenshotServer.ts
+++ b/src/lib/screenshot-server/DockerizedScreenshotServer.ts
@@ -5,7 +5,7 @@ import { ScreenshotServer } from "./api";
 import { getLoggingLevel } from "./config";
 
 const DOCKER_IMAGE_TAG_NAME = "fwouts/chrome-screenshot";
-const DOCKER_IMAGE_VERSION = "1.1.0";
+const DOCKER_IMAGE_VERSION = "1.2.0";
 const DOCKER_IMAGE_TAG = `${DOCKER_IMAGE_TAG_NAME}:${DOCKER_IMAGE_VERSION}`;
 
 const logDebug = debugLogger("DockerizedScreenshotServer");

--- a/src/lib/screenshot-server/config.ts
+++ b/src/lib/screenshot-server/config.ts
@@ -1,16 +1,20 @@
 import isDocker from "is-docker";
 import { LoggingConfig } from "../logger";
 
+export const SCREENSHOT_MODE = getScreenshotMode();
+
+const serverDefaultPort =
+  process.platform === "linux" && SCREENSHOT_MODE === "docker"
+    ? "3000"
+    : "3038";
 export const SCREENSHOT_SERVER_PORT = parseInt(
-  process.env.SCREENSHOT_SERVER_PORT || "3038",
+  process.env.SCREENSHOT_SERVER_PORT || serverDefaultPort,
   10
 );
 
 export const SCREENSHOT_SERVER_URL =
   process.env.SCREENSHOT_SERVER_URL ||
   `http://localhost:${SCREENSHOT_SERVER_PORT}`;
-
-export const SCREENSHOT_MODE = getScreenshotMode();
 
 function getScreenshotMode(): "puppeteer" | "selenium" | "docker" | "percy" {
   if (process.env.SCREENSHOT_MODE) {

--- a/src/lib/screenshot-server/config.ts
+++ b/src/lib/screenshot-server/config.ts
@@ -5,7 +5,7 @@ export const SCREENSHOT_MODE = getScreenshotMode();
 
 const serverDefaultPort =
   process.platform === "linux" && SCREENSHOT_MODE === "docker"
-    ? "3000"
+    ? "3001"
     : "3038";
 export const SCREENSHOT_SERVER_PORT = parseInt(
   process.env.SCREENSHOT_SERVER_PORT || serverDefaultPort,


### PR DESCRIPTION
There is no `host.docker.internal` on Linux ([link](https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal)), so to connect from container to host, we have to use `network=host`, otherwise, react-screenshot will always timeout.

I also change port to 3001 to avoid conflict since we will use host network on linux

TODO:
- Warn user about using host network for docker on linux in README
- Update image on docker hub
- More Linux user test?