### PR TITLE
fix: Remove check for screenshotserver to allow watch in jest

### DIFF
--- a/src/lib/global-setup.ts
+++ b/src/lib/global-setup.ts
@@ -25,10 +25,6 @@ export function getScreenshotServer() {
 export async function setUpScreenshotServer() {
   logDebug(`Screenshot server setup initiated.`);
 
-  if (screenshotServer) {
-    throw new Error("Please only call setUpScreenshotServer() once.");
-  }
-
   logDebug(`Creating screenshot server.`);
   screenshotServer = createScreenshotServer();
   logDebug(`Screenshot server instance created.`);


### PR DESCRIPTION
This allows you to run:

jest -c jest.screenshot.config.js --watch

So you can watch the changes to your components on the fly.