### PR TITLE
chore: upgrade puppeteer image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/puppeteer:v1.15.0
+FROM buildkite/puppeteer:7.1.0
 RUN apt-get -qqy update && \
     apt-get -qqy --no-install-recommends install \
     fonts-roboto \


### PR DESCRIPTION
Hi, in my CI (I'm using GitLab), when specifying docker image `fwouts/chrome-screenshot:1.2.0`, some of the dependencies that require node version `>= 10.19.0` fail to install because `fwouts/chrome-screenshot:1.2.0` has node version `10.15.3`.

In this PR, it simply upgrades using the latest puppeteer image, which has node version 14.15.4.