### PR TITLE
upgrade buildkite/puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/puppeteer:v1.15.0
+FROM buildkite/puppeteer:8.0.0
 RUN apt-get -qqy update && \
     apt-get -qqy --no-install-recommends install \
     fonts-roboto \


### PR DESCRIPTION
This PR updates puppeteer to allow for a newer chromium version. 

I have tested this change with a locally build docker image. All of the tests still work but the screenshot tests will render a very slightly different image especially when there is text in the image.

After this PR is merged a new docker image needs to be published and that docker image needs to be updated in this file `src/lib/screenshot-server/DockerizedScreenshotServer.ts`